### PR TITLE
Redirect root domain to getzooly.com

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,74 +1,26 @@
-import { useEffect, useState } from 'react'
-import Link from 'next/link'
-import { supabase } from '../lib/supabase'
-import { Survey } from '../types/survey'
+import { GetServerSideProps } from 'next'
 
 export default function Home() {
-  const [surveys, setSurveys] = useState<Survey[]>([])
-  const [loading, setLoading] = useState(true)
-
-  useEffect(() => {
-    fetchSurveys()
-  }, [])
-
-  const fetchSurveys = async () => {
-    try {
-      const { data, error } = await supabase
-        .from('surveys')
-        .select('*')
-        .eq('is_active', true)
-        .order('created_at', { ascending: false })
-
-      if (error) throw error
-      setSurveys(data || [])
-    } catch (error) {
-      console.error('Error fetching surveys:', error)
-    } finally {
-      setLoading(false)
-    }
-  }
-
+  // This should never render as we redirect on the server
   return (
-    <div style={{ maxWidth: '800px', margin: '0 auto', padding: '2rem' }}>
-      <h1>Available Surveys</h1>
-      
-      {loading ? (
-        <p>Loading surveys...</p>
-      ) : surveys.length === 0 ? (
-        <p>No active surveys available.</p>
-      ) : (
-        <div>
-          {surveys.map(survey => (
-            <div key={survey.id} style={{ 
-              border: '1px solid #ddd', 
-              padding: '1rem', 
-              marginBottom: '1rem',
-              borderRadius: '8px'
-            }}>
-              <h2>{survey.name}</h2>
-              <p>{survey.description}</p>
-              <Link 
-                href={`/survey/${survey.id}`}
-                style={{ 
-                  display: 'inline-block',
-                  padding: '0.5rem 1rem',
-                  backgroundColor: '#0070f3',
-                  color: 'white',
-                  textDecoration: 'none',
-                  borderRadius: '4px',
-                  marginTop: '0.5rem'
-                }}
-              >
-                Take Survey
-              </Link>
-            </div>
-          ))}
-        </div>
-      )}
-      
-      <div style={{ marginTop: '2rem' }}>
-        <Link href="/admin" style={{ color: '#0070f3' }}>Admin Dashboard →</Link>
-      </div>
+    <div style={{ 
+      display: 'flex', 
+      justifyContent: 'center', 
+      alignItems: 'center', 
+      minHeight: '100vh',
+      fontSize: '18px',
+      color: '#666'
+    }}>
+      Redirecting to Zooly...
     </div>
   )
+}
+
+export const getServerSideProps: GetServerSideProps = async () => {
+  return {
+    redirect: {
+      destination: 'https://getzooly.com',
+      permanent: false,
+    },
+  }
 }


### PR DESCRIPTION
- Replaced index page with server-side redirect to https://getzooly.com
- Users will access surveys directly via email invitation links
- Admin and API routes remain accessible at their specific paths
- Used getServerSideProps for immediate server-side redirect