### PR TITLE
Prevent search engine indexing of survey site

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -2,6 +2,12 @@ import { NextResponse } from 'next/server'
 import type { NextRequest } from 'next/server'
 
 export function middleware(request: NextRequest) {
+  // Create response with noindex headers for all routes
+  const response = NextResponse.next()
+  
+  // Add X-Robots-Tag header to prevent indexing
+  response.headers.set('X-Robots-Tag', 'noindex, nofollow, noarchive, nosnippet, noimageindex')
+  
   // Only protect /admin routes (but not admin-login)
   if (request.nextUrl.pathname.startsWith('/admin') && !request.nextUrl.pathname.startsWith('/admin-login')) {
     // Check for auth cookie
@@ -9,7 +15,7 @@ export function middleware(request: NextRequest) {
     
     // If we have an auth cookie with the correct prefix, allow access
     if (authCookie?.value && authCookie.value.startsWith('YXV0aGVk')) {
-      return NextResponse.next()
+      return response
     }
     
     // No valid auth, redirect to login page
@@ -18,9 +24,9 @@ export function middleware(request: NextRequest) {
     return NextResponse.redirect(loginUrl)
   }
 
-  return NextResponse.next()
+  return response
 }
 
 export const config = {
-  matcher: '/admin/:path*',
+  matcher: '/:path*',
 }

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -1,0 +1,27 @@
+import { Html, Head, Main, NextScript } from 'next/document'
+
+export default function Document() {
+  return (
+    <Html lang="en">
+      <Head>
+        {/* Prevent search engines from indexing this site */}
+        <meta name="robots" content="noindex, nofollow, noarchive, nosnippet, noimageindex" />
+        <meta name="googlebot" content="noindex, nofollow, noarchive, nosnippet, noimageindex" />
+        <meta name="bingbot" content="noindex, nofollow, noarchive, nosnippet, noimageindex" />
+        
+        {/* Additional SEO prevention */}
+        <meta name="rating" content="general" />
+        <meta name="referrer" content="no-referrer" />
+        
+        {/* Prevent caching by search engines */}
+        <meta httpEquiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
+        <meta httpEquiv="Pragma" content="no-cache" />
+        <meta httpEquiv="Expires" content="0" />
+      </Head>
+      <body>
+        <Main />
+        <NextScript />
+      </body>
+    </Html>
+  )
+}

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,23 @@
+# Prevent all search engines from indexing this site
+User-agent: *
+Disallow: /
+Crawl-delay: 86400
+
+# Specifically block major search engines
+User-agent: Googlebot
+Disallow: /
+
+User-agent: Bingbot
+Disallow: /
+
+User-agent: Slurp
+Disallow: /
+
+User-agent: DuckDuckBot
+Disallow: /
+
+User-agent: Baiduspider
+Disallow: /
+
+User-agent: YandexBot
+Disallow: /

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <!-- Empty sitemap - this site should not be indexed -->
+</urlset>


### PR DESCRIPTION
- Added comprehensive robots.txt to block all crawlers
- Created _document.tsx with noindex meta tags
- Updated middleware to add X-Robots-Tag headers to all responses
- Added empty sitemap.xml to indicate no indexable content
- Ensures survey.getzooly.com won't appear in search results